### PR TITLE
(endpoint): fetch models from v1/models endpoint

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -96,9 +96,9 @@ export default function Home() {
       if (!selectedHost) return;
 
       try {
-        const models = await getAvailableModels(selectedHost.baseUrl);
+        const models = await getAvailableModels(selectedHost.baseUrl, selectedHost.apiKey);
         if (models.length > 0) {
-          const newModel = models[0].name;
+          const newModel = models[0].id;
           if (newModel !== selectedHost.modelName) {
             // Update host configuration with new model
             const updatedHost = { ...selectedHost, modelName: newModel };

--- a/frontend/components/settings/AddHostForm.tsx
+++ b/frontend/components/settings/AddHostForm.tsx
@@ -34,7 +34,7 @@ export function AddHostForm({ onAdd, hostToEdit, onUpdate, onCancel }: AddHostFo
   useEffect(() => {
     if (baseUrl) {
       setIsLoading(true);
-      getAvailableModels(baseUrl)
+      getAvailableModels(baseUrl, apiKey)
         .then(models => {
           setAvailableModels(models);
           if (models.length > 0 && !modelName && !hostToEdit?.modelName) {

--- a/frontend/lib/openrouter.ts
+++ b/frontend/lib/openrouter.ts
@@ -145,16 +145,25 @@ export async function getOpenRouterStreamingCompletion(
   }
 }
 
-export async function getAvailableModels(baseUrl: string): Promise<OpenRouterModel[]> {
+export async function getAvailableModels(baseUrl: string, apiKey: string): Promise<OpenRouterModel[]> {
   try {
-    const response = await fetch(`${baseUrl}/models`);
+    const response = await fetch(`${baseUrl}/v1/models`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+        'HTTP-Referer': window.location.origin,
+        'X-Title': 'Compute Community Chat',
+        'ngrok-skip-browser-warning': 'true',
+      },
+    });
     if (!response.ok) {
       throw new Error('Failed to fetch models');
     }
     const data = await response.json();
-    return data.models || [];
+    return data.data || [];
   } catch (error) {
     console.error('Error fetching models:', error);
     return [];
   }
-} 
+}


### PR DESCRIPTION
closes #4 

r﻿equest header needs the following fields on top of v1/chat/completions
request header fields.

'ngrok-skip-browser-warning': 'true', (can be set to any value)
